### PR TITLE
Disable LibAV multithreading, again

### DIFF
--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -178,7 +178,7 @@ function h265AddParamSets(frame: Buffer, paramSets: H265ParamSets) {
 }
 
 const idToStream = new Map<string, Readable>();
-const libavPromise = LibAV.LibAV({ yesthreads: true });
+const libavPromise = LibAV.LibAV();
 libavPromise.then((libav) => {
     libav.onread = (id) => {
         idToStream.get(id)?.resume();


### PR DESCRIPTION
Demuxing probably doesn't use multiple threads anyway, and it might compete for threads with other stuff, namely encryption

cc @uwuv3, try the release published here