### PR TITLE
Add `AbortSignal` to `prepareStream` and `playStream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "@libav.js/variant-webcodecs": "^6.4.7",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
-        "p-cancelable": "^4.0.1",
         "p-debounce": "^4.0.0",
         "sodium-plus": "^0.9.0",
         "uid": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       fluent-ffmpeg:
         specifier: ^2.1.3
         version: 2.1.3
-      p-cancelable:
-        specifier: ^4.0.1
-        version: 4.0.1
       p-debounce:
         specifier: ^4.0.0
         version: 4.0.0
@@ -421,10 +418,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  p-cancelable@4.0.1:
-    resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
-    engines: {node: '>=14.16'}
 
   p-debounce@4.0.0:
     resolution: {integrity: sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A==}
@@ -1041,8 +1034,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  p-cancelable@4.0.1: {}
 
   p-debounce@4.0.0: {}
 

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -298,6 +298,7 @@ export function prepareStream(
         });
         command.on("end", () => resolve());
     })
+    promise.catch(() => {});
     cancelSignal?.addEventListener("abort", () => command.kill("SIGTERM"));
     command.run();
     
@@ -462,5 +463,5 @@ export async function playStream(
             cleanup();
             resolve();
         });
-    });
+    }).catch(() => {});
 }

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -299,7 +299,7 @@ export function prepareStream(
         command.on("end", () => resolve());
     })
     promise.catch(() => {});
-    cancelSignal?.addEventListener("abort", () => command.kill("SIGTERM"));
+    cancelSignal?.addEventListener("abort", () => command.kill("SIGTERM"), { once: true });
     command.run();
     
     return { command, output, promise }
@@ -456,7 +456,7 @@ export async function playStream(
         cancelSignal?.addEventListener("abort", () => {
             cleanup();
             reject(cancelSignal.reason);
-        })
+        }, { once: true })
         vStream.once("finish", () => {
             if (cancelSignal?.aborted)
                 return;


### PR DESCRIPTION
Adding this because while working on https://github.com/Discord-RE/FFmpeg-input-premade, I came across some cases where ending the stream is a bit more complicated than just a single `command.kill`, and having a unified way to end processes would be better for other users.

`AbortSignal` is chosen because many other Node APIs and libraries are using it as the way to abort processes.

```javascript
// Global variable
let controller = new AbortController();

const { command, output } = prepareStream(url, { ... }, controller.signal);
await playStream(output, streamer, { ... }, controller.signal);

// End everything
controller.abort();
```