### PR TITLE
Add ZeroMQ control mechanism + volume control example

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "sharp": "^0.33.5",
         "sodium-plus": "^0.9.0",
         "uid": "^2.0.2",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "zeromq": "^6.4.2"
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.18.0
+      zeromq:
+        specifier: ^6.4.2
+        version: 6.4.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -376,6 +379,10 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
+  cmake-ts@0.6.1:
+    resolution: {integrity: sha512-uUn2qGhf20j8W/sQ7+UnvvqO1zNccqgbLgwRJi7S23FsjMWJqxvKK80Vc+tvLNKfpJzwH0rgoQD1l24SMnX0yg==}
+    hasBin: true
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -536,6 +543,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-addon-api@8.3.1:
+    resolution: {integrity: sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -812,6 +823,10 @@ packages:
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  zeromq@6.4.2:
+    resolution: {integrity: sha512-FnQlI4lEAewE4JexJ6kqQuBVzRf0Mg1n/qE3uXilfosf+X5lqJPiaYfdL/w4SzgAEVBTyqbMt9NbjwI5H89Yaw==}
+    engines: {node: '>= 12'}
 
   zod-package-json@1.1.0:
     resolution: {integrity: sha512-RvEsa3W/NCqEBMtnoE09GRVelA3IqRcKaijEiM6CEGsD19qLurf0HjrYMHwOqImOszlLL0ja63DPJeeU4pm7oQ==}
@@ -1102,6 +1117,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  cmake-ts@0.6.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1259,6 +1276,8 @@ snapshots:
       ufo: 1.5.4
 
   ms@2.1.3: {}
+
+  node-addon-api@8.3.1: {}
 
   node-gyp-build@4.8.4: {}
 
@@ -1524,6 +1543,11 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  zeromq@6.4.2:
+    dependencies:
+      cmake-ts: 0.6.1
+      node-addon-api: 8.3.1
 
   zod-package-json@1.1.0:
     dependencies:

--- a/src/media/AudioStream.ts
+++ b/src/media/AudioStream.ts
@@ -1,45 +1,15 @@
-import type { MediaUdp } from "../client/index.js";
+import type { MediaUdp } from "../client/voice/MediaUdp.js";
 import { BaseMediaStream } from "./BaseMediaStream.js";
 
 export class AudioStream extends BaseMediaStream {
     public udp: MediaUdp;
-    private _isMuted = false;
 
     constructor(udp: MediaUdp, noSleep = false) {
         super("audio", noSleep);
         this.udp = udp;
     }
 
-    /**
-     * Mutes the audio stream. No audible audio frames will be sent, but empty frames will be sent for synchronization.
-     */
-    public mute(): void {
-        this._isMuted = true;
-    }
-
-    /**
-     * Unmutes the audio stream. Audio frames will resume sending.
-     */
-    public unmute(): void {
-        this._isMuted = false;
-    }
-
-    /**
-     * Checks if the audio stream is currently muted.
-     * @returns True if muted, false otherwise.
-     */
-    public isMuted(): boolean {
-        return this._isMuted;
-    }
-
     protected override async _sendFrame(frame: Buffer, frametime: number): Promise<void> {
-        if (this._isMuted) {
-            // If muted, send an empty audio frame for synchronization.
-            // The empty audio frame is 0xF8 0xFF 0xFE.
-            const emptyFrame = Buffer.from([0xF8, 0xFF, 0xFE]);
-            await this.udp.sendAudioFrame(emptyFrame, frametime);
-            return;
-        }
         await this.udp.sendAudioFrame(frame, frametime);
     }
 }

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -94,6 +94,11 @@ export type EncoderOptions = {
     customFfmpegFlags: string[]
 }
 
+export type Controller = {
+    volume: number,
+    setVolume(newVolume: number): Promise<boolean>
+};
+
 export function prepareStream(
     input: string | Readable,
     options: Partial<EncoderOptions> = {},
@@ -360,7 +365,7 @@ export function prepareStream(
                     return false;
                 }
             }
-        }
+        } satisfies Controller
     }
 }
 

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -15,12 +15,6 @@ import LibAV from '@lng2004/libav.js-variant-webcodecs-avf-with-decoders';
 import type { SupportedVideoCodec } from '../utils.js';
 import type { MediaUdp, Streamer } from '../client/index.js';
 
-export interface Controller {
-    mute(): void;
-    unmute(): void;
-    isMuted(): boolean;
-}
-
 export type EncoderOptions = {
     /**
      * Disable video transcoding
@@ -134,45 +128,45 @@ export function prepareStream(
 
             width:
                 isFiniteNonZero(opts.width) ? Math.round(opts.width) : defaultOptions.width,
-
+    
             height:
                 isFiniteNonZero(opts.height) ? Math.round(opts.height) : defaultOptions.height,
-
+    
             frameRate:
                 isFiniteNonZero(opts.frameRate) && opts.frameRate > 0
                     ? opts.frameRate
                     : defaultOptions.frameRate,
-
+    
             videoCodec:
                 opts.videoCodec ?? defaultOptions.videoCodec,
-
+    
             bitrateVideo:
                 isFiniteNonZero(opts.bitrateVideo) && opts.bitrateVideo > 0
                     ? Math.round(opts.bitrateVideo)
                     : defaultOptions.bitrateVideo,
-
+    
             bitrateVideoMax:
                 isFiniteNonZero(opts.bitrateVideoMax) && opts.bitrateVideoMax > 0
                     ? Math.round(opts.bitrateVideoMax)
                     : defaultOptions.bitrateVideoMax,
-
+    
             bitrateAudio:
                 isFiniteNonZero(opts.bitrateAudio) && opts.bitrateAudio > 0
                     ? Math.round(opts.bitrateAudio)
                     : defaultOptions.bitrateAudio,
-
+    
             includeAudio:
                 opts.includeAudio ?? defaultOptions.includeAudio,
-
+    
             hardwareAcceleratedDecoding:
                 opts.hardwareAcceleratedDecoding ?? defaultOptions.hardwareAcceleratedDecoding,
-
+    
             minimizeLatency:
                 opts.minimizeLatency ?? defaultOptions.minimizeLatency,
-
+    
             h26xPreset:
                 opts.h26xPreset ?? defaultOptions.h26xPreset,
-
+    
             customHeaders: {
                 ...defaultOptions.customHeaders, ...opts.customHeaders
             },
@@ -329,7 +323,7 @@ export function prepareStream(
     promise.catch(() => {});
     cancelSignal?.addEventListener("abort", () => command.kill("SIGTERM"), { once: true });
     command.run();
-
+    
     return { command, output, promise }
 }
 
@@ -466,12 +460,9 @@ export async function playStream(
 
     const vStream = new VideoStream(udp);
     video.stream.pipe(vStream);
-
-    let aStream: AudioStream | undefined; // Declare the audio stream instance
-
     if (audio)
     {
-        aStream = new AudioStream(udp);
+        const aStream = new AudioStream(udp);
         audio.stream.pipe(aStream);
         vStream.syncStream = aStream;
         aStream.syncStream = vStream;
@@ -484,10 +475,8 @@ export async function playStream(
             const stopBurst = (pts: number) => {
                 if (pts < burstTime * 1000)
                     return;
-                // biome-ignore lint/style/noNonNullAssertion:
-                vStream.sync = aStream!.sync = true;
-                // biome-ignore lint/style/noNonNullAssertion:
-                vStream.noSleep = vStream!.sync = false;
+                vStream.sync = aStream.sync = true;
+                vStream.noSleep = aStream.noSleep = false;
                 vStream.off("pts", stopBurst);
             }
             vStream.on("pts", stopBurst);
@@ -535,8 +524,7 @@ export async function playStream(
             cleanupFuncs.push(() => video.stream.off("data", updatePreview));
         })();
     }
-
-    const streamPromise = new Promise<void>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         cleanupFuncs.push(() => {
             stopStream();
             udp.mediaConnection.setSpeaking(false);
@@ -561,20 +549,4 @@ export async function playStream(
             resolve();
         });
     }).catch(() => {});
-
-    // Return the promise and the controller
-    return {
-        controller: {
-            mute() {
-                aStream?.mute();
-            },
-            unmute() {
-                aStream?.unmute();
-            },
-            isMuted() {
-                return !!aStream?.isMuted();
-            }
-        } satisfies Controller,
-        done: streamPromise
-    };
 }

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -133,45 +133,45 @@ export function prepareStream(
 
             width:
                 isFiniteNonZero(opts.width) ? Math.round(opts.width) : defaultOptions.width,
-    
+
             height:
                 isFiniteNonZero(opts.height) ? Math.round(opts.height) : defaultOptions.height,
-    
+
             frameRate:
                 isFiniteNonZero(opts.frameRate) && opts.frameRate > 0
                     ? opts.frameRate
                     : defaultOptions.frameRate,
-    
+
             videoCodec:
                 opts.videoCodec ?? defaultOptions.videoCodec,
-    
+
             bitrateVideo:
                 isFiniteNonZero(opts.bitrateVideo) && opts.bitrateVideo > 0
                     ? Math.round(opts.bitrateVideo)
                     : defaultOptions.bitrateVideo,
-    
+
             bitrateVideoMax:
                 isFiniteNonZero(opts.bitrateVideoMax) && opts.bitrateVideoMax > 0
                     ? Math.round(opts.bitrateVideoMax)
                     : defaultOptions.bitrateVideoMax,
-    
+
             bitrateAudio:
                 isFiniteNonZero(opts.bitrateAudio) && opts.bitrateAudio > 0
                     ? Math.round(opts.bitrateAudio)
                     : defaultOptions.bitrateAudio,
-    
+
             includeAudio:
                 opts.includeAudio ?? defaultOptions.includeAudio,
-    
+
             hardwareAcceleratedDecoding:
                 opts.hardwareAcceleratedDecoding ?? defaultOptions.hardwareAcceleratedDecoding,
-    
+
             minimizeLatency:
                 opts.minimizeLatency ?? defaultOptions.minimizeLatency,
-    
+
             h26xPreset:
                 opts.h26xPreset ?? defaultOptions.h26xPreset,
-    
+
             customHeaders: {
                 ...defaultOptions.customHeaders, ...opts.customHeaders
             },
@@ -313,7 +313,7 @@ export function prepareStream(
 
     // realtime control mechanism
     const zmqEndpoint = "tcp://localhost:42069";
-    command.videoFilter(`zmq=b=${zmqEndpoint}`);
+    command.videoFilter(`zmq=b="${zmqEndpoint}"`);
     const zmqClient = new zmq.Request({ immediate: true, sendTimeout: 1000, receiveTimeout: 1000 });
     output.once("data", () => {
         zmqClient.connect(zmqEndpoint);

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -313,7 +313,7 @@ export function prepareStream(
 
     // realtime control mechanism
     const zmqAudio = "tcp://localhost:42069";
-    const zmqAudioClient = new zmq.Request({ immediate: true, sendTimeout: 1000, receiveTimeout: 1000 });
+    const zmqAudioClient = new zmq.Request({ sendTimeout: 5000, receiveTimeout: 5000 });
 
     if (includeAudio)
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
   
       /* Language and Environment */
-      "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+      "target": "es2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
       // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
       // "jsx": "preserve",                                /* Specify what JSX code is generated. */
       // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
- Supersedes https://github.com/Discord-RE/Discord-video-stream/pull/172

https://github.com/user-attachments/assets/fce3e56e-5441-42d9-90aa-09986c9f06a2

The listening port is picked ~~because it's funny~~ so that it's unlikely to conflict with ports that might be already bound by other programs. However since the port is fixed, this prevents multiple instances from running at the same time. If this is a problem, I'll implement an auto port scanning mechanism.

Requires an FFmpeg build with `libzmq` enabled. I recommend https://github.com/BtbN/FFmpeg-Builds on Windows and Linux. For macOS, compile by yourself, sorry.