### PR TITLE
Rewrite stream sync mechanism + high water mark tweak

### DIFF
--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -15,8 +15,8 @@ export class BaseMediaStream extends Writable {
     private _startTime?: number;
     private _startPts?: number;
     private _sync = true;
+    private _syncStream?: BaseMediaStream;
 
-    public syncStream?: BaseMediaStream;
     constructor(type: string, noSleep = false) {
         super({ objectMode: true, highWaterMark: 0 });
         this._loggerSend = new Log(`stream:${type}:send`);
@@ -34,6 +34,15 @@ export class BaseMediaStream extends Writable {
             this._loggerSync.debug("Sync enabled");
         else
             this._loggerSync.debug("Sync disabled");
+    }
+    get syncStream() {
+        return this._syncStream;
+    }
+    set syncStream(stream: BaseMediaStream | undefined)
+    {
+        if (stream !== undefined && this === stream.syncStream)
+            throw new Error("Cannot sync 2 streams with eachother");
+        this._syncStream = stream;
     }
     get noSleep(): boolean {
         return this._noSleep;
@@ -134,7 +143,7 @@ export class BaseMediaStream extends Writable {
                 }, `Stream is ahead. Waiting for ${frametime}ms`);
                 await setTimeout(frametime);
             }
-            while (this.isAhead())
+            while (this.isAhead());
         }
         else
         {

--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -144,6 +144,7 @@ export class BaseMediaStream extends Writable {
                 await setTimeout(frametime);
             }
             while (this.isAhead());
+            callback(null);
         }
         else
         {

--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -6,7 +6,7 @@ import type { Packet } from "@lng2004/libav.js-variant-webcodecs-avf-with-decode
 
 export class BaseMediaStream extends Writable {
     private _pts?: number;
-    private _syncTolerance = 5;
+    private _syncTolerance = 20;
     private _loggerSend: Log;
     private _loggerSync: Log;
     private _loggerSleep: Log;

--- a/src/media/BaseMediaStream.ts
+++ b/src/media/BaseMediaStream.ts
@@ -74,11 +74,11 @@ export class BaseMediaStream extends Writable {
     }
     private isAhead() {
         const delta = this.ptsDelta();
-        return delta !== undefined && delta > this.syncTolerance;
+        return this.syncStream?.writableEnded === false && delta !== undefined && delta > this.syncTolerance;
     }
     private isBehind() {
         const delta = this.ptsDelta();
-        return delta !== undefined && delta < -this.syncTolerance;
+        return this.syncStream?.writableEnded === false && delta !== undefined && delta < -this.syncTolerance;
     }
     private resetTimingCompensation() {
         this._startTime = this._startPts = undefined;

--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -227,8 +227,8 @@ export async function demux(input: Readable, cancelSignal?: AbortSignal) {
     const aStream = streams.find((stream) => stream.codec_type === libav.AVMEDIA_TYPE_AUDIO)
     let vInfo: VideoStreamInfo | undefined
     let aInfo: AudioStreamInfo | undefined;
-    const vPipe = new PassThrough({ objectMode: true, highWaterMark: 128 });
-    const aPipe = new PassThrough({ objectMode: true, highWaterMark: 128 });
+    const vPipe = new PassThrough({ objectMode: true, writableHighWaterMark: 128 });
+    const aPipe = new PassThrough({ objectMode: true, writableHighWaterMark: 128 });
 
     if (vStream) {
         if (!allowedVideoCodec.has(vStream.codec_id)) {

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -511,17 +511,16 @@ export async function playStream(
         const aStream = new AudioStream(udp);
         audio.stream.pipe(aStream);
         vStream.syncStream = aStream;
-        aStream.syncStream = vStream;
 
         const burstTime = mergedOptions.readrateInitialBurst;
         if (typeof burstTime === "number")
         {
-            vStream.sync = aStream.sync = false;
+            vStream.sync = false;
             vStream.noSleep = aStream.noSleep = true;
             const stopBurst = (pts: number) => {
                 if (pts < burstTime * 1000)
                     return;
-                vStream.sync = aStream.sync = true;
+                vStream.sync = true;
                 vStream.noSleep = aStream.noSleep = false;
                 vStream.off("pts", stopBurst);
             }


### PR DESCRIPTION
This rewrites the syncing logic to be more in-line with how media players do syncing. The audio stream is played at a regular cadence, while the video stream will drop/repeat frames to stay in sync with the audio. When adapted to this use case, it results in the video stream either not sleeping ("dropping frames") or sleep for an extra frame ("repeating frames").

All these changes together allow me to get <0.5s latency, timed by sending a volume adjust command and timing the delay between the bot's response and the audio adjusting (not scientific but it's a lot better than before). Badly behaving streams will still have a delay, because of more buffering required for proper syncing.