### PR TITLE
Use `nut` as a transport format

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -7,14 +7,18 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["./examples/**/*"]
+		"includes": ["./src"]
 	},
 	"formatter": {
 		"enabled": false,
 		"indentStyle": "tab"
 	},
-	"organizeImports": {
-		"enabled": false
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "off"
+			}
+		}
 	},
 	"linter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-actuallyworking",
+        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-pthread-fixes",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "p-debounce": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-pthread-fixes",
+        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-bsf-full-api",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "p-debounce": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.5.7-o3",
+        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "p-debounce": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7",
+        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-actuallyworking",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "p-debounce": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lng2004/libav.js-variant-webcodecs-avf-with-decoders':
-        specifier: 6.5.7-o3
-        version: 6.5.7-o3
+        specifier: 6.7.7
+        version: 6.7.7
       debug-level:
         specifier: ^3.2.1
         version: 3.2.1
@@ -244,8 +244,8 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.5.7-o3':
-    resolution: {integrity: sha512-JAMdrXIEH4SHevJ44r4lXEdIRvINgij0rKiJLfnzwig1wSXQmcLDmWYDAQ0qefcjuqj9Bt8rswgrKDAT4GV97g==}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7':
+    resolution: {integrity: sha512-aInI1TMYrL2ccAUM8ahphBGKQMy6RBEwwB+90v8SnP3mQ3GT6q/MTHrs5qaqhPryfQTvdC9TCqEAPUJta0bqYQ==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -977,7 +977,7 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.1.0
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.5.7-o3': {}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7': {}
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lng2004/libav.js-variant-webcodecs-avf-with-decoders':
-        specifier: 6.7.7
-        version: 6.7.7
+        specifier: 6.7.7-actuallyworking
+        version: 6.7.7-actuallyworking
       debug-level:
         specifier: ^3.2.1
         version: 3.2.1
@@ -244,8 +244,8 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7':
-    resolution: {integrity: sha512-aInI1TMYrL2ccAUM8ahphBGKQMy6RBEwwB+90v8SnP3mQ3GT6q/MTHrs5qaqhPryfQTvdC9TCqEAPUJta0bqYQ==}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-actuallyworking':
+    resolution: {integrity: sha512-HEBeeTgzYx/9OWY+fpzFearPM+b5vO/LNji8VTgqS+rBltSLVdaKiVAO5wmJMm+HkLbFR3Gg5F84e8Cz+jfl5g==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -977,7 +977,7 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.1.0
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7': {}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-actuallyworking': {}
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lng2004/libav.js-variant-webcodecs-avf-with-decoders':
-        specifier: 6.7.7-pthread-fixes
-        version: 6.7.7-pthread-fixes
+        specifier: 6.7.7-bsf-full-api
+        version: 6.7.7-bsf-full-api
       debug-level:
         specifier: ^3.2.1
         version: 3.2.1
@@ -244,8 +244,8 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-pthread-fixes':
-    resolution: {integrity: sha512-/X6nsDypDNVxmeEBvfO2n+6ZT7BSUlstpue4RAeDEnu2IoYp5EuHPbp8B/np0pDVnvv8zY6eJZfMcjbQI74qfw==}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-bsf-full-api':
+    resolution: {integrity: sha512-mZII6CtZo+IOxq2xfzzxu0XFkS20EMzObbK5LZgjqGKEbAFVSZQVJn6S8SG7YhfF+OnoVzmkJnYez8tTLyMVqw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -484,6 +484,7 @@ packages:
   fluent-ffmpeg@2.1.3:
     resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
     engines: {node: '>=18'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -977,7 +978,7 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.1.0
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-pthread-fixes': {}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-bsf-full-api': {}
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lng2004/libav.js-variant-webcodecs-avf-with-decoders':
-        specifier: 6.7.7-actuallyworking
-        version: 6.7.7-actuallyworking
+        specifier: 6.7.7-pthread-fixes
+        version: 6.7.7-pthread-fixes
       debug-level:
         specifier: ^3.2.1
         version: 3.2.1
@@ -244,8 +244,8 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-actuallyworking':
-    resolution: {integrity: sha512-HEBeeTgzYx/9OWY+fpzFearPM+b5vO/LNji8VTgqS+rBltSLVdaKiVAO5wmJMm+HkLbFR3Gg5F84e8Cz+jfl5g==}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-pthread-fixes':
+    resolution: {integrity: sha512-/X6nsDypDNVxmeEBvfO2n+6ZT7BSUlstpue4RAeDEnu2IoYp5EuHPbp8B/np0pDVnvv8zY6eJZfMcjbQI74qfw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -977,7 +977,7 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.1.0
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-actuallyworking': {}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-pthread-fixes': {}
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/src/client/encryptor/TransportEncryptor.ts
+++ b/src/client/encryptor/TransportEncryptor.ts
@@ -13,7 +13,7 @@ export class AES256TransportEncryptor implements TransportEncryptor
     constructor(secretKey: Buffer)
     {
         this._secretKey = crypto.subtle.importKey("raw", 
-            secretKey,
+            Buffer.from(secretKey),
             {
                 name: "AES-GCM",
                 length: 32
@@ -29,8 +29,8 @@ export class AES256TransportEncryptor implements TransportEncryptor
         const ciphertext = Buffer.from(await crypto.subtle.encrypt({
             name: "AES-GCM",
             iv: nonceBuffer,
-            additionalData,
-        }, await this._secretKey, plaintext));
+            additionalData: Buffer.from(additionalData),
+        }, await this._secretKey, Buffer.from(plaintext)));
 
         return [ciphertext, nonceBuffer]
     }

--- a/src/client/packet/BaseMediaPacketizer.ts
+++ b/src/client/packet/BaseMediaPacketizer.ts
@@ -143,7 +143,7 @@ export class BaseMediaPacketizer {
             packetHeader[1] |= 0b10000000; // mark M bit if last frame
     
         packetHeader.writeUIntBE(this.getNewSequence(), 2, 2);
-        packetHeader.writeUIntBE(this._timestamp, 4, 4);
+        packetHeader.writeUIntBE(Math.round(this._timestamp), 4, 4);
         packetHeader.writeUIntBE(this._ssrc, 8, 4);
         return packetHeader;
     }
@@ -169,7 +169,7 @@ export class BaseMediaPacketizer {
 
         senderReport.writeUInt32BE(ntpTimestampMsw, 0);
         senderReport.writeUInt32BE(ntpTimestampLsw, 4);
-        senderReport.writeUInt32BE(this._timestamp, 8);
+        senderReport.writeUInt32BE(Math.round(this._timestamp), 8);
         senderReport.writeUInt32BE(this._totalPackets % max_int32bit, 12);
         senderReport.writeUInt32BE(this._totalBytes, 16);
 

--- a/src/client/packet/VideoPacketizerAnnexB.ts
+++ b/src/client/packet/VideoPacketizerAnnexB.ts
@@ -6,7 +6,7 @@ import {
     type AnnexBHelpers
 } from "../processing/AnnexBHelper.js";
 import { extensions } from "../../utils.js";
-import { splitNaluLengthPrefixed } from "../processing/AnnexBHelper.js";
+import { splitNalu } from "../processing/AnnexBHelper.js";
 import { CodecPayloadType } from "../voice/BaseMediaConnection.js";
 
 /**
@@ -74,7 +74,7 @@ class VideoPacketizerAnnexB extends BaseMediaPacketizer {
     public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {
         super.sendFrame(frame, frametime);
 
-        const nalus = splitNaluLengthPrefixed(frame);
+        const { nalus } = splitNalu(frame);
 
         let packetsSent = 0;
         let bytesSent = 0;

--- a/src/client/packet/VideoPacketizerAnnexB.ts
+++ b/src/client/packet/VideoPacketizerAnnexB.ts
@@ -6,7 +6,7 @@ import {
     type AnnexBHelpers
 } from "../processing/AnnexBHelper.js";
 import { extensions } from "../../utils.js";
-import { splitNalu } from "../processing/AnnexBHelper.js";
+import { splitNaluLengthPrefixed } from "../processing/AnnexBHelper.js";
 import { CodecPayloadType } from "../voice/BaseMediaConnection.js";
 
 /**
@@ -74,7 +74,7 @@ class VideoPacketizerAnnexB extends BaseMediaPacketizer {
     public override async sendFrame(frame: Buffer, frametime: number): Promise<void> {
         super.sendFrame(frame, frametime);
 
-        const nalus = splitNalu(frame);
+        const nalus = splitNaluLengthPrefixed(frame);
 
         let packetsSent = 0;
         let bytesSent = 0;

--- a/src/client/processing/AnnexBHelper.ts
+++ b/src/client/processing/AnnexBHelper.ts
@@ -114,8 +114,11 @@ export const H265Helpers: AnnexBHelpers = {
     }
 }
 
-// Get individual NAL units from an AVPacket frame
-export function splitNalu(frame: Buffer) {
+export const startCode3 = Buffer.from([0, 0, 1]);
+export const startCode4 = Buffer.from([0, 0, 0, 1]);
+
+// Get individual NAL units from a length-prefixed NALU buffer
+export function splitNaluLengthPrefixed(frame: Buffer) {
     const nalus = [];
     let offset = 0;
     while (offset < frame.length) {
@@ -128,8 +131,8 @@ export function splitNalu(frame: Buffer) {
     return nalus;
 }
 
-// Merge NAL units into an AVPacket frame
-export function mergeNalu(nalus: Buffer[])
+// Merge NAL units into a length-prefixed NALU buffer
+export function mergeNaluLengthPrefixed(nalus: Buffer[])
 {
     const chunks = [];
     for (const nalu of nalus)
@@ -143,12 +146,11 @@ export function mergeNalu(nalus: Buffer[])
 
 export function splitNaluAnnexB(buf: Buffer)
 {
-    const startCode = Buffer.from([0, 0, 1]);
     let temp: Buffer | null = buf;
     const nalus: Buffer[] = [];
     while (temp?.byteLength)
     {
-        let pos = temp.indexOf(startCode);
+        let pos = temp.indexOf(startCode3);
         let length = 3;
         if (pos > 0 && temp[pos - 1] == 0)
         {

--- a/src/client/processing/AnnexBHelper.ts
+++ b/src/client/processing/AnnexBHelper.ts
@@ -164,3 +164,24 @@ export function splitNaluAnnexB(buf: Buffer)
     }
     return nalus;
 }
+
+export function mergeNaluAnnexB(nalus: Buffer[])
+{
+    return Buffer.concat(
+        nalus.flatMap(nalu => [startCode3, nalu])
+    )
+}
+
+export function splitNalu(buf: Buffer)
+{
+    const isAnnexB = buf.subarray(0, 3).equals(startCode3) || buf.subarray(0, 4).equals(startCode4);
+    return {
+        isAnnexB,
+        nalus: isAnnexB ? splitNaluAnnexB(buf) : splitNaluLengthPrefixed(buf)
+    }
+}
+
+export function mergeNalu(nalus: Buffer[], annexB: boolean)
+{
+    return annexB ? mergeNaluAnnexB(nalus) : mergeNaluLengthPrefixed(nalus);
+}

--- a/src/client/processing/AnnexBHelper.ts
+++ b/src/client/processing/AnnexBHelper.ts
@@ -150,7 +150,7 @@ export function splitNaluAnnexB(buf: Buffer)
     const nalus: Buffer[] = [];
     while (temp?.byteLength)
     {
-        let pos = temp.indexOf(startCode3);
+        let pos: number = temp.indexOf(startCode3);
         let length = 3;
         if (pos > 0 && temp[pos - 1] == 0)
         {

--- a/src/client/processing/AnnexBHelper.ts
+++ b/src/client/processing/AnnexBHelper.ts
@@ -140,3 +140,25 @@ export function mergeNalu(nalus: Buffer[])
     }
     return Buffer.concat(chunks);
 }
+
+export function splitNaluAnnexB(buf: Buffer)
+{
+    const startCode = Buffer.from([0, 0, 1]);
+    let temp: Buffer | null = buf;
+    const nalus: Buffer[] = [];
+    while (temp?.byteLength)
+    {
+        let pos = temp.indexOf(startCode);
+        let length = 3;
+        if (pos > 0 && temp[pos - 1] == 0)
+        {
+            pos--;
+            length++;
+        }
+        const nalu = pos == -1 ? temp : temp.subarray(0, pos);
+        temp = pos == -1 ? null : temp.subarray(pos + length);
+        if (nalu.byteLength)
+            nalus.push(nalu);
+    }
+    return nalus;
+}

--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -248,7 +248,7 @@ function h264AddParamSets(frame: Buffer, paramSets: H264ParamSets) {
         chunks.push(...sps);
     if (!hasPPS)
         chunks.push(...pps);
-    return mergeNalu(nalus, isAnnexB);
+    return mergeNalu([...chunks, ...nalus], isAnnexB);
 }
 
 function h265AddParamSets(frame: Buffer, paramSets: H265ParamSets) {
@@ -282,7 +282,7 @@ function h265AddParamSets(frame: Buffer, paramSets: H265ParamSets) {
         chunks.push(...sps);
     if (!hasPPS)
         chunks.push(...pps);
-    return mergeNalu(nalus, isAnnexB);
+    return mergeNalu([...chunks, ...nalus], isAnnexB);
 }
 
 const idToStream = new Map<string, Readable>();

--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -16,14 +16,14 @@ type MediaStreamInfoCommon = {
     codec: AVCodecID,
     codecpar: CodecParameters,
 }
-type VideoStreamInfo = MediaStreamInfoCommon & {
+export type VideoStreamInfo = MediaStreamInfoCommon & {
     width: number,
     height: number,
     framerate_num: number,
     framerate_den: number,
     extradata?: unknown
 }
-type AudioStreamInfo = MediaStreamInfoCommon & {
+export type AudioStreamInfo = MediaStreamInfoCommon & {
     sample_rate: number
 };
 
@@ -186,7 +186,13 @@ libavInstance.then((libav) => {
     }
 })
 
-export async function demux(input: Readable, cancelSignal?: AbortSignal) {
+type DemuxerOptions = {
+    format: "matroska" | "nut"
+}
+
+export async function demux(input: Readable, {
+    format
+}: DemuxerOptions) {
     const loggerInput = new Log("demux:input");
     const loggerFormat = new Log("demux:format");
     const loggerFrameCommon = new Log("demux:frame:common");
@@ -209,7 +215,7 @@ export async function demux(input: Readable, cancelSignal?: AbortSignal) {
     input.on("data", ondata);
     input.on("end", onend);
 
-    const [fmt_ctx, streams] = await libav.ff_init_demuxer_file(filename, "matroska");
+    const [fmt_ctx, streams] = await libav.ff_init_demuxer_file(filename, format);
     const pkt = await libav.av_packet_alloc();
 
     const cleanup = () => {

--- a/src/media/LibavDemuxer.ts
+++ b/src/media/LibavDemuxer.ts
@@ -1,15 +1,8 @@
 import pDebounce from "p-debounce";
-import LibAV, { type CodecParameters } from "@lng2004/libav.js-variant-webcodecs-avf-with-decoders";
+import LibAV, { type CodecParameters, type Packet } from "@lng2004/libav.js-variant-webcodecs-avf-with-decoders";
 import { Log } from "debug-level";
 import { uid } from "uid";
 import { AVCodecID } from "./LibavCodecId.js";
-import {
-    H264Helpers, H264NalUnitTypes,
-    H265Helpers, H265NalUnitTypes,
-    splitNalu, mergeNalu,
-    splitNaluAnnexB,
-    startCode3, startCode4
-} from "../client/processing/AnnexBHelper.js";
 import { PassThrough } from "node:stream";
 import type { Readable } from "node:stream";
 
@@ -23,14 +16,10 @@ export type VideoStreamInfo = MediaStreamInfoCommon & {
     height: number,
     framerate_num: number,
     framerate_den: number,
-    extradata?: unknown
 }
 export type AudioStreamInfo = MediaStreamInfoCommon & {
     sample_rate: number
 };
-
-type H264ParamSets = Record<"sps" | "pps", Buffer[]>
-type H265ParamSets = Record<"vps" | "sps" | "pps", Buffer[]>
 
 const allowedVideoCodec = new Set([
     AVCodecID.AV_CODEC_ID_H264,
@@ -43,129 +32,6 @@ const allowedVideoCodec = new Set([
 const allowedAudioCodec = new Set([
     AVCodecID.AV_CODEC_ID_OPUS
 ]);
-
-// Parse H264 extradata, which can be either in Annex B or avcC format
-function parseH264ParamSets(input: Buffer) {
-    let buf = input;
-    if (
-        buf.subarray(0, 3).equals(startCode3) ||
-        buf.subarray(0, 4).equals(startCode4)
-    )
-    {
-        // Annex B
-        const sps: Buffer[] = [];
-        const pps: Buffer[] = [];
-        for (const nalu of splitNaluAnnexB(buf))
-        {
-            const naluType = H264Helpers.getUnitType(nalu);
-            switch (naluType)
-            {
-                case H264NalUnitTypes.SPS:
-                    sps.push(nalu);
-                    break;
-                case H264NalUnitTypes.PPS:
-                    pps.push(nalu);
-                    break;
-            }
-        }
-        return { sps, pps }
-    }
-    if (buf[0] !== 1)
-        throw new Error("Only configurationVersion 1 is supported");
-    // Skip a bunch of stuff we don't care about
-    buf = buf.subarray(5);
-
-    const sps: Buffer[] = [];
-    const pps: Buffer[] = [];
-
-    // Read the SPS
-    const spsCount = buf[0] & 0b11111;
-    buf = buf.subarray(1);
-    for (let i = 0; i < spsCount; ++i) {
-        const spsLength = buf.readUInt16BE();
-        buf = buf.subarray(2);
-        sps.push(buf.subarray(0, spsLength));
-        buf = buf.subarray(spsLength);
-    }
-
-    // Read the PPS
-    const ppsCount = buf[0];
-    buf = buf.subarray(1);
-    for (let i = 0; i < ppsCount; ++i) {
-        const ppsLength = buf.readUInt16BE();
-        buf = buf.subarray(2);
-        pps.push(buf.subarray(0, ppsLength));
-        buf = buf.subarray(ppsLength);
-    }
-    return { sps, pps }
-}
-
-// Parse H265 extradata, which can be either in Annex B or hvcC format
-function parseH265ParamSets(input: Buffer) {
-    let buf = input;
-    if (
-        buf.subarray(0, 3).equals(Buffer.from([0, 0, 1])) ||
-        buf.subarray(0, 4).equals(Buffer.from([0, 0, 0, 1]))
-    )
-    {
-        // Annex B
-        const vps: Buffer[] = [];
-        const sps: Buffer[] = [];
-        const pps: Buffer[] = [];
-        for (const nalu of splitNaluAnnexB(buf))
-        {
-            const naluType = H265Helpers.getUnitType(nalu);
-            switch (naluType)
-            {
-                case H265NalUnitTypes.VPS_NUT:
-                    vps.push(nalu);
-                    break;
-                case H265NalUnitTypes.SPS_NUT:
-                    sps.push(nalu);
-                    break;
-                case H265NalUnitTypes.PPS_NUT:
-                    pps.push(nalu);
-                    break;
-            }
-        }
-        return { vps, sps, pps }
-    }
-    if (buf[0] !== 1)
-        throw new Error("Only configurationVersion 1 is supported");
-    // Skip a bunch of stuff we don't care about
-    buf = buf.subarray(22);
-
-    const vps: Buffer[] = [];
-    const sps: Buffer[] = [];
-    const pps: Buffer[] = [];
-
-    const numOfArrays = buf[0];
-    buf = buf.subarray(1);
-
-    for (let i = 0; i < numOfArrays; ++i) {
-        const naluType = buf[0] & 0b111111;
-        buf = buf.subarray(1);
-
-        const naluCount = buf.readUInt16BE();
-        buf = buf.subarray(2);
-
-        for (let j = 0; j < naluCount; ++j) {
-            const naluLength = buf.readUInt16BE();
-            buf = buf.subarray(2);
-
-            const nalu = buf.subarray(0, naluLength);
-            buf = buf.subarray(naluLength);
-
-            if (naluType === H265NalUnitTypes.VPS_NUT)
-                vps.push(nalu);
-            else if (naluType === H265NalUnitTypes.SPS_NUT)
-                sps.push(nalu);
-            else if (naluType === H265NalUnitTypes.PPS_NUT)
-                pps.push(nalu);
-        }
-    }
-    return { vps, sps, pps }
-}
 
 function parseOpusPacketDuration(frame: Uint8Array)
 {
@@ -222,69 +88,6 @@ function parseOpusPacketDuration(frame: Uint8Array)
     return frameSize * frameCount;
 }
 
-function h264AddParamSets(frame: Buffer, paramSets: H264ParamSets) {
-    const { sps, pps } = paramSets;
-    const { nalus, isAnnexB } = splitNalu(frame);
-    // Technically non-IDR I frames exist ("open GOP"), but they're exceedingly
-    // rare in the wild, and no encoder produces it by default
-    let isIDR = false;
-    let hasSPS = false;
-    let hasPPS = false;
-    for (const nalu of nalus) {
-        const naluType = H264Helpers.getUnitType(nalu);
-        if (naluType === H264NalUnitTypes.CodedSliceIdr)
-            isIDR = true;
-        else if (naluType === H264NalUnitTypes.SPS)
-            hasSPS = true;
-        else if (naluType === H264NalUnitTypes.PPS)
-            hasPPS = true;
-    }
-    if (!isIDR) {
-        // Not an IDR, return as is
-        return frame;
-    }
-    const chunks = [];
-    if (!hasSPS)
-        chunks.push(...sps);
-    if (!hasPPS)
-        chunks.push(...pps);
-    return mergeNalu([...chunks, ...nalus], isAnnexB);
-}
-
-function h265AddParamSets(frame: Buffer, paramSets: H265ParamSets) {
-    const { vps, sps, pps } = paramSets;
-    const { nalus, isAnnexB } = splitNalu(frame);
-    // Technically non-IDR I frames exist ("open GOP"), but they're exceedingly
-    // rare in the wild, and no encoder produces it by default
-    let isIDR = false;
-    let hasVPS = false;
-    let hasSPS = false;
-    let hasPPS = false;
-    for (const nalu of nalus) {
-        const naluType = H265Helpers.getUnitType(nalu);
-        if (naluType === H265NalUnitTypes.IDR_N_LP || naluType === H265NalUnitTypes.IDR_W_RADL)
-            isIDR = true;
-        else if (naluType === H265NalUnitTypes.VPS_NUT)
-            hasVPS = true;
-        else if (naluType === H265NalUnitTypes.SPS_NUT)
-            hasSPS = true;
-        else if (naluType === H265NalUnitTypes.PPS_NUT)
-            hasPPS = true;
-    }
-    if (!isIDR) {
-        // Not an IDR, return as is
-        return frame;
-    }
-    const chunks = [];
-    if (!hasVPS)
-        chunks.push(...vps);
-    if (!hasSPS)
-        chunks.push(...sps);
-    if (!hasPPS)
-        chunks.push(...pps);
-    return mergeNalu([...chunks, ...nalus], isAnnexB);
-}
-
 const idToStream = new Map<string, Readable>();
 const libavInstance = LibAV.LibAV();
 libavInstance.then((libav) => {
@@ -331,6 +134,7 @@ export async function demux(input: Readable, {
         input.off("data", ondata);
         input.off("end", onend);
         idToStream.delete(filename);
+        vbsf && libav.av_bsf_free_js(vbsf);
         libav.avformat_close_input_js(fmt_ctx);
         libav.av_packet_free(pkt);
         libav.unlink(filename);
@@ -343,37 +147,43 @@ export async function demux(input: Readable, {
     const vPipe = new PassThrough({ objectMode: true, writableHighWaterMark: 128 });
     const aPipe = new PassThrough({ objectMode: true, writableHighWaterMark: 128 });
 
+    let vbsf: number;
     if (vStream) {
         if (!allowedVideoCodec.has(vStream.codec_id)) {
             const codecName = await libav.avcodec_get_name(vStream.codec_id);
             cleanup();
             throw new Error(`Video codec ${codecName} is not allowed`)
         }
-        const codecpar = await libav.ff_copyout_codecpar(vStream.codecpar);
+        let bsf = "null";
+        switch (vStream.codec_id)
+        {
+            case AVCodecID.AV_CODEC_ID_H264:
+                bsf = "h264_mp4toannexb,dump_extra";
+                break;
+            case AVCodecID.AV_CODEC_ID_HEVC:
+                bsf = "hevc_mp4toannexb,dump_extra";
+                break;
+        }
+        vbsf = await libav.av_bsf_list_parse_str_js(bsf);
+        if (!vbsf)
+            throw new Error(`Failed to construct bitstream filterchain: ${bsf}`);
+
+        // av_bsf_free() will free par_in, so we have to make a copy of the original codecpar
+        const par_in = await libav.avcodec_parameters_alloc();
+        await libav.avcodec_parameters_copy(par_in, vStream.codecpar);
+        await libav.AVBSFContext_par_in_s(vbsf, par_in);
+        await libav.AVBSFContext_time_base_in_s(vbsf, vStream.time_base_num, vStream.time_base_den);
+        await libav.av_bsf_init(vbsf);
+        const codecpar_ptr = await libav.AVBSFContext_par_out(vbsf);
+        const codecpar = await libav.ff_copyout_codecpar(codecpar_ptr);
         vInfo = {
             index: vStream.index,
             codec: vStream.codec_id,
             codecpar,
             width: codecpar.width ?? 0,
             height: codecpar.height ?? 0,
-            framerate_num: await libav.AVCodecParameters_framerate_num(vStream.codecpar),
-            framerate_den: await libav.AVCodecParameters_framerate_den(vStream.codecpar),
-        }
-        if (vStream.codec_id === AVCodecID.AV_CODEC_ID_H264) {
-            const { extradata } = codecpar;
-            vInfo = {
-                ...vInfo,
-                // biome-ignore lint/style/noNonNullAssertion: will always be non-null for our use case
-                extradata: parseH264ParamSets(Buffer.from(extradata!))
-            }
-        }
-        else if (vStream.codec_id === AVCodecID.AV_CODEC_ID_H265) {
-            const { extradata } = codecpar;
-            vInfo = {
-                ...vInfo,
-                // biome-ignore lint/style/noNonNullAssertion: will always be non-null for our use case
-                extradata: parseH265ParamSets(Buffer.from(extradata!))
-            }
+            framerate_num: await libav.AVCodecParameters_framerate_num(codecpar_ptr),
+            framerate_den: await libav.AVCodecParameters_framerate_den(codecpar_ptr),
         }
         loggerFormat.info({
             info: vInfo
@@ -402,42 +212,44 @@ export async function demux(input: Readable, {
         while (resume) {
             const [status, streams] = await libav.ff_read_frame_multi(fmt_ctx, pkt, {
                 limit: 1,
-                unify: true
+                unify: true,
+                copyoutPacket: "ptr"
             });
             for (const packet of streams[0] ?? []) {
-                if (vInfo && vInfo.index === packet.stream_index) {
-                    if (vInfo.codec === AVCodecID.AV_CODEC_ID_H264) {
-                        packet.data = h264AddParamSets(
-                            Buffer.from(packet.data),
-                            // biome-ignore lint/style/noNonNullAssertion: will always be non-null for our use case
-                            vInfo.extradata! as H264ParamSets
-                        );
-                    }
-                    else if (vInfo.codec === AVCodecID.AV_CODEC_ID_H265) {
-                        packet.data = h265AddParamSets(
-                            Buffer.from(packet.data),
-                            // biome-ignore lint/style/noNonNullAssertion: will always be non-null for our use case
-                            vInfo.extradata! as H265ParamSets
-                        );
-                    }
-                    resume &&= vPipe.write(packet);
+                const stream_index = await libav.AVPacket_stream_index(packet);
+                if (vInfo && vInfo.index === stream_index) {
+                    const packet_bsf: Packet[] = await libav.ff_bsf_multi(vbsf, pkt, [packet]);
+                    packet_bsf.forEach((packet) => resume &&= vPipe.write(packet));
                     loggerFrameVideo.trace("Pushed a frame into the video pipe");
+                    // packet is freed by ff_copyin_packet
                 }
-                else if (aInfo && aInfo.index === packet.stream_index) {
-                    packet.duration ||= parseOpusPacketDuration(packet.data);
-                    resume &&= aPipe.write(packet);
+                else if (aInfo && aInfo.index === stream_index) {
+                    const packet_copyout = await libav.ff_copyout_packet(packet);
+                    packet_copyout.duration ||= parseOpusPacketDuration(packet_copyout.data);
+                    resume &&= aPipe.write(packet_copyout);
                     loggerFrameAudio.trace("Pushed a frame into the audio pipe");
+                    await libav.av_packet_free_js(packet);
+                }
+                else {
+                    // Free unused packets to prevent memory leak
+                    await libav.av_packet_free_js(packet);
                 }
             }
             if (status < 0 && status !== -libav.EAGAIN) {
                 // End of file, or some error happened
+                if (status === LibAV.AVERROR_EOF)
+                {
+                    loggerFrameCommon.info("Reached end of stream. Stopping");
+                    const packet_bsf: Packet[] = await libav.ff_bsf_multi(vbsf, pkt, [], { fin: true });
+                    packet_bsf.forEach((packet) => resume &&= vPipe.write(packet));
+                }
+                else
+                {
+                    loggerFrameCommon.info({ status }, "Received an error during frame extraction. Stopping");
+                }
                 cleanup();
                 vPipe.end();
                 aPipe.end();
-                if (status === LibAV.AVERROR_EOF)
-                    loggerFrameCommon.info("Reached end of stream. Stopping");
-                else
-                    loggerFrameCommon.info({ status }, "Received an error during frame extraction. Stopping");
                 return;
             }
             if (!resume) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export const extensions = [{ id: 5, len: 2, val: 0 }];
 export const max_int16bit = 2 ** 16;
 export const max_int32bit = 2 ** 32;
 
-export function isFiniteNonZero(n: number | undefined): n is number {
+export function isFiniteNonZero(n: unknown): n is number {
     return !!n && Number.isFinite(n);
 }
 


### PR DESCRIPTION
`nut` is a [very simple generic container format](https://ffmpeg.org/nut.html), probably a good idea to use this instead of the more complex `matroska` for interprocess purposes

This will be a breaking change for people using `playStream` with their custom streams. They'll need to change their output format to `nut`, or specify `format: "matroska"` in the `playStream` option