### PR TITLE
Disable the volume control on Deno and Bun due to ZeroMQ dependency

### DIFF
--- a/src/media/LibavDecoder.ts
+++ b/src/media/LibavDecoder.ts
@@ -7,12 +7,19 @@ export async function createDecoder(id: number, codecpar: LibAV.CodecParameters)
 {
     if (isDeno() || isBun())
     {
-        console.error(
-            "The decoder currently doesn't work with Deno and Bun, due to " +
-            "various issues with Emscripten's pthread support leading to "  +
-            "crashes. The decoder will not be initialized"
-        );
-        return null;
+        if (process.env.LIBAVDECODER_FORCE_ENABLED)
+        {
+            console.error("Video decoder force enabled. Here be dragons!")
+        }
+        else
+        {
+            console.error(
+                "The decoder currently doesn't work with Deno and Bun, due to " +
+                "various issues with Emscripten's pthread support leading to "  +
+                "crashes. The decoder will not be initialized"
+            );
+            return null;
+        }
     }
     libavInstance ??= LibAV.LibAV({ yesthreads: true });
     let freed = false;

--- a/src/media/LibavDecoder.ts
+++ b/src/media/LibavDecoder.ts
@@ -1,16 +1,11 @@
-import { AV_PIX_FMT_RGBA, AVMEDIA_TYPE_VIDEO } from "@lng2004/libav.js-variant-webcodecs-avf-with-decoders";
-import LibAV from "@lng2004/libav.js-variant-webcodecs-avf-with-decoders";
+import LibAV, { AV_PIX_FMT_RGBA, AVMEDIA_TYPE_VIDEO } from "@lng2004/libav.js-variant-webcodecs-avf-with-decoders";
+import { isDeno, isBun } from "../utils.js";
 
 let libavInstance: Promise<LibAV.LibAV>;
 
-// @ts-expect-error
-const isDeno = typeof Deno !== "undefined";
-// @ts-expect-error
-const isBun = typeof Bun !== "undefined";
-
 export async function createDecoder(id: number, codecpar: LibAV.CodecParameters)
 {
-    if (isDeno || isBun)
+    if (isDeno() || isBun())
     {
         console.error(
             "The decoder currently doesn't work with Deno and Bun, due to " +

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -566,7 +566,10 @@ export async function playStream(
                 if (!(packet.flags !== undefined && packet.flags & LibAV.AV_PKT_FLAG_KEY))
                     return;
                 const decodeStart = performance.now();
-                const [frame] = await decoder.decode([packet]).catch(() => []);
+                const [frame] = await decoder.decode([packet]).catch((e) => {
+                    logger.error(e, "Failed to decode the frame");
+                    return []
+                });
                 if (!frame)
                     return;
                 const decodeEnd = performance.now();

--- a/src/media/newApi.ts
+++ b/src/media/newApi.ts
@@ -6,7 +6,7 @@ import { PassThrough, type Readable } from "node:stream";
 import { demux } from './LibavDemuxer.js';
 import { VideoStream } from './VideoStream.js';
 import { AudioStream } from './AudioStream.js';
-import { isBun, isFiniteNonZero } from '../utils.js';
+import { isBun, isDeno, isFiniteNonZero } from '../utils.js';
 import { AVCodecID } from './LibavCodecId.js';
 import { createDecoder } from './LibavDecoder.js';
 
@@ -334,7 +334,7 @@ export function prepareStream(
     const zmqAudioClient = (async() => {
         if (!includeAudio)
             return null;
-        if (isBun())
+        if (isBun() || isDeno())
             return null;
         const zmqEndpoint = "tcp://localhost:42069";
         command.audioFilters(`azmq=b=${zmqEndpoint.replaceAll(":","\\\\:")}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,3 +75,15 @@ export function generateStreamKey(type: "guild" | "call", guildId: string | null
 export function isVoiceChannel(channel: AnyChannel): channel is DMChannel | GroupDMChannel | VoiceBasedChannel {
     return (channel.type === "DM" || channel.type === "GROUP_DM" || channel.type === "GUILD_STAGE_VOICE" || channel.type === "GUILD_VOICE")
 }
+
+export function isDeno()
+{
+    // @ts-expect-error
+    return typeof Deno !== "undefined";
+}
+
+export function isBun()
+{
+    // @ts-expect-error
+    return typeof Bun !== "undefined";
+}


### PR DESCRIPTION
Deno and Bun doesn't support the `zeromq` package yet. Until support is added (or maybe until Bun does its own thing and integrates the library into the runtime), disable the feature on those runtimes. Also added an override flag for decoder initialization for easy testing.