### PR TITLE
Update libav.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.7.7-bsf-full-api",
+        "@lng2004/libav.js-variant-webcodecs-avf-with-decoders": "6.8.8-simd-lto",
         "debug-level": "^3.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "p-debounce": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lng2004/libav.js-variant-webcodecs-avf-with-decoders':
-        specifier: 6.7.7-bsf-full-api
-        version: 6.7.7-bsf-full-api
+        specifier: 6.8.8-simd-lto
+        version: 6.8.8-simd-lto
       debug-level:
         specifier: ^3.2.1
         version: 3.2.1
@@ -244,8 +244,8 @@ packages:
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
     engines: {node: '>=10'}
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-bsf-full-api':
-    resolution: {integrity: sha512-mZII6CtZo+IOxq2xfzzxu0XFkS20EMzObbK5LZgjqGKEbAFVSZQVJn6S8SG7YhfF+OnoVzmkJnYez8tTLyMVqw==}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.8.8-simd-lto':
+    resolution: {integrity: sha512-NhsOIIwhFyA/ffgw90YpMrqian+YxOyFLmQD2br02UJ7Bl0sNhkc7eRUhliDLM1BMZnDbNeqKT07I0OXxZD21Q==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -978,7 +978,7 @@ snapshots:
       string-argv: 0.3.2
       type-detect: 4.1.0
 
-  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.7.7-bsf-full-api': {}
+  '@lng2004/libav.js-variant-webcodecs-avf-with-decoders@6.8.8-simd-lto': {}
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
        "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
       // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
       // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
       // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
        "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
       // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
Updating to libav.js 6.8.8.0 and enable WebAssembly SIMD support, which may or may not improve decoding performance, but since Node.js supported it since v16, why not. I know at least some HEVC decoding functions have hand-written SIMD versions, so those will definitely help.